### PR TITLE
Adjust deposit and key money step handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,12 +313,12 @@
       </div>
       <div class="form-group">
         <label for="deposit" class="tooltip" data-tooltip="通常0-2ヶ月分">敷金 (ヶ月)</label>
-        <input type="number" id="deposit" value="1" min="0" max="12" step="0.1">
+        <input type="number" id="deposit" value="1" min="0" max="12" step="1">
         <div class="error-message" id="error-deposit"></div>
       </div>
       <div class="form-group">
         <label for="keyMoney" class="tooltip" data-tooltip="通常0-2ヶ月分">礼金 (ヶ月)</label>
-        <input type="number" id="keyMoney" value="1" min="0" max="12" step="0.1">
+        <input type="number" id="keyMoney" value="1" min="0" max="12" step="1">
         <div class="error-message" id="error-keyMoney"></div>
       </div>
       <div class="form-group">
@@ -632,6 +632,24 @@
     // 入力時のリアルタイムバリデーション
     document.addEventListener('DOMContentLoaded', () => {
       const inputs = document.querySelectorAll('input[type="number"], input[type="date"]');
+      const adjustableStepInputs = ['deposit', 'keyMoney']
+        .map(id => document.getElementById(id))
+        .filter(Boolean);
+
+      adjustableStepInputs.forEach(input => {
+        input.addEventListener('input', () => {
+          if (input.value.includes('.')) {
+            input.step = 'any';
+          } else {
+            input.step = '1';
+          }
+        });
+
+        input.addEventListener('blur', () => {
+          input.step = '1';
+        });
+      });
+
       inputs.forEach(input => {
         input.addEventListener('blur', () => {
           const id = input.id;


### PR DESCRIPTION
## Summary
- update the deposit and key money fields to use a default step of 1 so the spinner advances in whole-month increments
- add DOMContentLoaded listeners that temporarily switch the step to `any` when decimals are typed and restore `1` on blur to keep manual fractional entries valid

## Testing
- Manual verification in the browser_container to confirm 1-month spinner steps and acceptance of decimal inputs

------
https://chatgpt.com/codex/tasks/task_b_68d646e399108323b218c873c4a2dd05